### PR TITLE
Add option to suppress global mapping

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,3 +45,19 @@ useful for adding a space behind or in front of the checkbox:
 
 Inserting a checkbox can be disabled by setting `g:insert_checkbox` to an
 empty string (`''`).
+
+Mapping
+-------
+
+By default a global mapping is `<leader>tt` used.  This can cause problems if
+you already use that mapping and this plugin is lazy-loaded.
+In this case you can to suppress this mapping by setting:
+
+    let g:checkbox_suppress_mapping = 1
+
+And the map the command however you want.  For example, a buffer local mapping
+for Markdown files only by adding the following to `.vim/ftplugin/markdown.vim:`
+
+```vim
+map <buffer><silent><leader>tt :call checkbox#ToggleCB()<cr>
+```

--- a/plugin/checkbox.vim
+++ b/plugin/checkbox.vim
@@ -82,6 +82,8 @@ endf
 
 command! ToggleCB call checkbox#ToggleCB()
 
-map <silent> <leader>tt :call checkbox#ToggleCB()<cr>
+if !exists('g:checkbox_suppress_mapping') || g:checkbox_suppress_mapping != 1
+    map <silent> <leader>tt :call checkbox#ToggleCB()<cr>
+endif
 
 let g:loaded_checkbox = 1


### PR DESCRIPTION
This makes it easier to override the global `<leader>tt` mapping if it clashes with you own settings. 

If you lazy-load this plugin using vim-plug, it can be a bit of a challenge to override this mapping -- you have to put an `autocmd` on the `User` event.  Being able to suppress the mapping makes this a lot easier.   