### PR TITLE
Allow disabling/overriding the default keymap

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,3 +45,8 @@ useful for adding a space behind or in front of the checkbox:
 
 Inserting a checkbox can be disabled by setting `g:insert_checkbox` to an
 empty string (`''`).
+
+The default keymap can be customized by setting the following:
+
+    let g:checkbox_create_maps = 0
+    map <silent> <your_key_map_here> :call checkbox#ToggleCB()<CR>

--- a/plugin/checkbox.vim
+++ b/plugin/checkbox.vim
@@ -32,6 +32,11 @@
 "
 " Inserting a checkbox can be disabled by setting g:insert_checkbox to an
 " empty string ('').
+"
+" The default keymap can be customized by setting the following:
+"
+"     let g:checkbox_create_maps = 0
+"     map <silent> <your_key_map_here> :call checkbox#ToggleCB()<CR>
 " ****************************************************************************
 
 if exists('g:loaded_checkbox')
@@ -82,6 +87,9 @@ endf
 
 command! ToggleCB call checkbox#ToggleCB()
 
-map <silent> <leader>tt :call checkbox#ToggleCB()<cr>
+" Create keymaps only if configured to do so (defaults to 'yes')
+if get(g:, 'checkbox_create_maps', 1)
+  map <silent> <leader>tt :call checkbox#ToggleCB()<cr>
+endif
 
 let g:loaded_checkbox = 1


### PR DESCRIPTION
If a user wants to set they're own key map for the toggle function, the one set by this plugin still exists. This can obviously just be overridden in the user's `vimrc`, but this is cleaner.

EDIT: just saw this is a dupe of https://github.com/jkramer/vim-checkbox/pull/8; no idea why that was closed