### PR TITLE
Add `vim-repeat` & make mapping configurable

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -25,6 +25,18 @@ Installation
 Just copy the script into your plugin folder, e.g. `~/.vim/plugin/`. If you're
 using pathogen, just clone this repository in `~/.vim/bundle`.
 
+Custom mappings
+---------------
+
+If you do not want to use `<leader>tt` you can set it via e.g.:
+
+```text
+augroup checkbox_mappings
+    nnoremap <leader>oo <plug>ToggleCheckbox
+augroup END
+```
+
+Hint: In this case the default mapping `<leader>tt` will not be configured.
 
 Usage
 -----

--- a/README.markdown
+++ b/README.markdown
@@ -11,6 +11,14 @@ Simple plugin that toggles text checkboxes in Vim. Works great if you're using
 a markdown file for notes and todo lists.
 
 
+Requirements
+------------
+
+The action provided by this plugin can be repeated with the native
+action `.`.
+This is provided by `tpope/vim-repeat`. Please be sure to install it
+before installing this plugin.
+
 Installation
 ------------
 

--- a/plugin/checkbox.vim
+++ b/plugin/checkbox.vim
@@ -57,7 +57,7 @@ if !exists('g:insert_checkbox_suffix')
   let g:insert_checkbox_suffix = ' '
 endif
 
-fu! checkbox#ToggleCB()
+fu! s:ToggleCB()
 	let line = getline('.')
 
   if(match(line, '\[.\]') != -1)
@@ -78,10 +78,15 @@ fu! checkbox#ToggleCB()
   endif
 
 	call setline('.', line)
+
+    silent! call repeat#set("\<plug>CheckboxToggle")
 endf
 
-command! ToggleCB call checkbox#ToggleCB()
 
-map <silent> <leader>tt :call checkbox#ToggleCB()<cr>
+nnoremap <silent> <leader>tt <plug>CheckboxToggle<cr>
+nnoremap <silent> <plug>CheckboxToggle
+                  \ :<c-u>call <sid>ToggleCB()<cr>
+
+command! ToggleCB  :call <sid>ToggleCB()
 
 let g:loaded_checkbox = 1

--- a/plugin/checkbox.vim
+++ b/plugin/checkbox.vim
@@ -79,12 +79,12 @@ fu! s:ToggleCB()
 
 	call setline('.', line)
 
-    silent! call repeat#set("\<plug>CheckboxToggle")
+    silent! call repeat#set("\<plug>ToggleCheckbox")
 endf
 
 
-nnoremap <silent> <leader>tt <plug>CheckboxToggle<cr>
-nnoremap <silent> <plug>CheckboxToggle
+nnoremap <silent> <leader>tt <plug>ToggleCheckbox<cr>
+nnoremap <silent> <plug>ToggleCheckbox
                   \ :<c-u>call <sid>ToggleCB()<cr>
 
 command! ToggleCB  :call <sid>ToggleCB()

--- a/plugin/checkbox.vim
+++ b/plugin/checkbox.vim
@@ -83,7 +83,11 @@ fu! s:ToggleCB()
 endf
 
 
-nnoremap <silent> <leader>tt <plug>ToggleCheckbox<cr>
+
+if !hasmapto('<Plug>ToggleCheckbox')
+    nmap <leader>tt <plug>ToggleCheckbox
+endif
+
 nnoremap <silent> <plug>ToggleCheckbox
                   \ :<c-u>call <sid>ToggleCB()<cr>
 


### PR DESCRIPTION
We use `tpope/vim-repeat` to enable plugin action repeats. So if you first <leader>tt you can then . to repeat the action.